### PR TITLE
Fix cfxCommander.doOption 

### DIFF
--- a/modules/commander.lua
+++ b/modules/commander.lua
@@ -93,7 +93,13 @@ function cfxCommander.doOption(data)
 		trigger.action.outText("Commander: setting option " .. data.key .. " --> " .. data.value, 30)
 	end
 
+	if not data.group or not Group.isExist(data.group) then 
+		-- group doesn't exist, skip
+		return nil 
+	end
+
 	local theController = data.group:getController()
+	if not theController then return nil end 
 	theController:setOption(data.key, data.value)
 end
 


### PR DESCRIPTION
I ran into this while triggering the explosion script and groups disappeared. Now the doOption does validate group existence and controller presence before setting options